### PR TITLE
Add Ray support to similarity transform

### DIFF
--- a/transforms/language/similarity/Dockerfile.ray
+++ b/transforms/language/similarity/Dockerfile.ray
@@ -1,0 +1,33 @@
+ARG BASE_IMAGE=docker.io/rayproject/ray:2.24.0-py310
+
+FROM ${BASE_IMAGE}
+
+# see https://docs.openshift.com/container-platform/4.17/openshift_images/create-images.html#use-uid_create-images
+USER root
+RUN chown ray:root /home/ray && chmod g=u /home/ray
+USER ray
+
+RUN pip install --upgrade --no-cache-dir pip 
+
+# install pytest
+RUN pip install --no-cache-dir pytest
+ARG DPK_WHEEL_FILE_NAME
+
+# Copy and install data processing libraries 
+# These are expected to be placed in the docker context before this is run (see the make image).
+COPY --chmod=775 --chown=ray:root data-processing-dist data-processing-dist
+RUN  pip install data-processing-dist/${DPK_WHEEL_FILE_NAME}[ray]
+
+## Copy the python version of the tansform
+COPY --chmod=775 --chown=ray:root dpk_similarity/ dpk_similarity/
+COPY --chmod=775 --chown=ray:root requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+# Set environment
+ENV PYTHONPATH /home/ray
+
+# Put these at the end since they seem to upset the docker cache.
+ARG BUILD_DATE
+ARG GIT_COMMIT
+LABEL build-date=$BUILD_DATE
+LABEL git-commit=$GIT_COMMIT

--- a/transforms/language/similarity/Makefile
+++ b/transforms/language/similarity/Makefile
@@ -35,3 +35,24 @@ run-local-python-sample:
 	$(MAKE) venv
 	@source venv/bin/activate && \
 	$(PYTHON) -m dpk_$(TRANSFORM_NAME).local_python
+
+run-ray-cli-sample: 
+	$(MAKE) venv
+	source venv/bin/activate && \
+	$(PYTHON) -m dpk_$(TRANSFORM_NAME).ray.transform \
+				--data_local_config "{ 'input_folder' : 'test-data/input', 'output_folder' : 'output'}"  \
+				--similarity_es_pwd $(SIMILARITY_ES_PWD) \
+				--similarity_es_userid $(SIMILARITY_ES_USERID) \
+				--similarity_es_endpoint $(SIMILARITY_ES_ENDPOINT) \
+				--similarity_es_index $(SIMILARITY_ES_INDEX)
+
+run-ray-s3-sample: 
+	$(MAKE) venv
+	source venv/bin/activate && \
+	$(PYTHON) -m dpk_$(TRANSFORM_NAME).ray.s3 \
+				--data_local_config "{ 'input_folder' : 'test-data/input', 'output_folder' : 'output'}"  \
+				--similarity_es_pwd $(SIMILARITY_ES_PWD) \
+				--similarity_es_userid $(SIMILARITY_ES_USERID) \
+				--similarity_es_endpoint $(SIMILARITY_ES_ENDPOINT) \
+				--similarity_es_index $(SIMILARITY_ES_INDEX)
+			

--- a/transforms/language/similarity/dpk_similarity/ray/__init__.py
+++ b/transforms/language/similarity/dpk_similarity/ray/__init__.py
@@ -1,0 +1,1 @@
+from .transform import *

--- a/transforms/language/similarity/dpk_similarity/ray/local_ray.py
+++ b/transforms/language/similarity/dpk_similarity/ray/local_ray.py
@@ -1,0 +1,51 @@
+# (C) Copyright IBM Corp. 2024.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import os
+import sys
+
+from data_processing.utils import ParamsUtils
+from data_processing_ray.runtime.ray import RayTransformLauncher
+from dpk_similarity.ray.transform import SimilarityRayRuntimeConfiguration
+
+
+# create parameters
+input_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "test-data", "input"))
+output_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../..", "output"))
+local_conf = {
+    "input_folder": input_folder,
+    "output_folder": output_folder,
+}
+worker_options = {"num_cpus": 0.8}
+code_location = {"github": "github", "commit_hash": "12345", "path": "path"}
+params = {
+    # where to run
+    "run_locally": True,
+    # Data access. Only required parameters are specified
+    "data_local_config": ParamsUtils.convert_to_ast(local_conf),
+    # orchestrator
+    "runtime_worker_options": ParamsUtils.convert_to_ast(worker_options),
+    "runtime_num_workers": 3,
+    "runtime_pipeline_id": "pipeline_id",
+    "runtime_job_id": "job_id",
+    "runtime_creation_delay": 0,
+    "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
+    # noop params
+    "noop_sleep_sec": 1,
+}
+if __name__ == "__main__":
+    # Set the simulated command line args
+    sys.argv = ParamsUtils.dict_to_req(d=params)
+    # create launcher
+    launcher = RayTransformLauncher(SimilarityRayRuntimeConfiguration())
+    # Launch the ray actor(s) to process the input
+    launcher.launch()

--- a/transforms/language/similarity/dpk_similarity/ray/s3.py
+++ b/transforms/language/similarity/dpk_similarity/ray/s3.py
@@ -1,0 +1,54 @@
+# (C) Copyright IBM Corp. 2024.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import os
+import sys
+
+from data_processing.utils import ParamsUtils
+from data_processing_ray.runtime.ray import RayTransformLauncher
+from dpk_similarity.ray.transform import SimilarityRayTransformRuntimeConfiguration
+
+
+# create launcher
+launcher = RayTransformLauncher(SimilarityRayTransformRuntimeConfiguration())
+# create parameters
+s3_cred = {
+    "access_key": "localminioaccesskey",
+    "secret_key": "localminiosecretkey",
+    "url": "http://localhost:9000",
+}
+
+s3_conf = {
+    "input_folder": "test/similarity/input",
+    "output_folder": "test/similarity/output",
+}
+worker_options = {"num_cpus": 0.8}
+code_location = {"github": "github", "commit_hash": "12345", "path": "path"}
+params = {
+    # where to run
+    "run_locally": True,
+    # Data access. Only required parameters are specified
+    "data_s3_cred": ParamsUtils.convert_to_ast(s3_cred),
+    "data_s3_config": ParamsUtils.convert_to_ast(s3_conf),
+    # orchestrator
+    "runtime_worker_options": ParamsUtils.convert_to_ast(worker_options),
+    "runtime_num_workers": 3,
+    "runtime_pipeline_id": "pipeline_id",
+    "runtime_job_id": "job_id",
+    "runtime_creation_delay": 0,
+    "runtime_code_location": ParamsUtils.convert_to_ast(code_location),
+}
+
+
+sys.argv = ParamsUtils.dict_to_req(d=params)
+# launch
+launcher.launch()

--- a/transforms/language/similarity/dpk_similarity/ray/transform.py
+++ b/transforms/language/similarity/dpk_similarity/ray/transform.py
@@ -1,0 +1,40 @@
+# (C) Copyright IBM Corp. 2024.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import sys
+
+from data_processing.utils import get_logger
+from data_processing_ray.runtime.ray import RayTransformLauncher
+from data_processing_ray.runtime.ray.runtime_configuration import RayTransformRuntimeConfiguration
+from dpk_similarity.transform import SimilarityTransformConfiguration
+
+logger = get_logger(__name__, level="INFO")
+
+class SimilarityRayTransformRuntimeConfiguration(RayTransformRuntimeConfiguration):
+    """
+    Implements the RayRuntimeConfiguration for Similarity as required by the RayTransformLauncher.
+    """
+
+    def __init__(self):
+        """
+        Initialization
+        :param base_configuration - base configuration class
+        """
+        super().__init__(transform_config=SimilarityTransformConfiguration())
+
+
+
+if __name__ == "__main__":
+    launcher = RayTransformLauncher(SimilarityRayTransformRuntimeConfiguration())
+    logger.info("Launching similarity transform")
+    launcher.launch()
+
+    

--- a/transforms/language/similarity/test/test_similarity_ray.py
+++ b/transforms/language/similarity/test/test_similarity_ray.py
@@ -1,0 +1,40 @@
+# (C) Copyright IBM Corp. 2024.
+# Licensed under the Apache License, Version 2.0 (the “License”);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+
+import pyarrow as pa
+# from data_processing.test_support import get_tables_in_folder
+from data_processing.test_support.launch.transform_test import (
+    AbstractTransformLauncherTest,
+)
+from data_processing_ray.runtime.ray import RayTransformLauncher
+from dpk_similarity.transform import  ES_ENDPOINT_KEY
+from dpk_similarity.ray.transform import SimilarityRayTransformRuntimeConfiguration
+
+class TestRaySimilarityTransform(AbstractTransformLauncherTest):
+    """
+    Extends the super-class to define the test data for the tests defined there.
+    The name of this class MUST begin with the word Test so that pytest recognizes it as a test class.
+    """
+    ## Unit Test should be run from the test folder
+    ## cd test && pytest .    
+    def get_test_transform_fixtures(self) -> list[tuple]:
+        
+        basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test-data"))
+
+        cli_params = {
+            "run_locally": True,
+        }
+        fixtures = []
+        launcher = RayTransformLauncher(SimilarityRayTransformRuntimeConfiguration())
+        fixtures.append((launcher, cli_params, os.path.join(basedir, "input"), os.path.join(basedir, "expected")))
+        return fixtures


### PR DESCRIPTION
## Why are these changes needed?

This PR adds Ray support to the `similarity` transform to enable distributed execution and improve performance on large datasets. By parallelizing the workload, we can reduce processing time and better utilize available compute resources.

## Related issue number (if any).


